### PR TITLE
support for syntax highlighting using unified plugins

### DIFF
--- a/components/code_block.js
+++ b/components/code_block.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components'
+
+export const Code = styled.code`
+    background-color: #eee;
+`
+
+export const Pre = styled.pre`
+    background-color: #eee;
+    border-left: 6px solid #00458b;
+    font-size: 1rem;
+    line-height: 1.4;
+    margin: 0 0 24px;
+    max-width: 100%;
+    overflow: auto;
+    padding: 24px;
+    width: 100%;
+`

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -1,8 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
-import remark from 'remark'
-import html from 'remark-html'
 
 const postsDirectory = path.join(process.cwd(), 'posts')
 
@@ -18,6 +16,8 @@ export function getSortedPostsData() {
         const fileContents = fs.readFileSync(fullPath, 'utf8')
 
         // Use gray-matter to parse the post metadata section
+        // `matter(fileContents)` returns an object where the front-matter
+        // is stored in `matterResult.data` and the content in `matterResult.content`
         const matterResult = matter(fileContents)
 
         // Combine the data with the id
@@ -56,15 +56,16 @@ export async function getPostData(id) {
     const matterResult = matter(fileContents);
 
     // Use remark to convert markdown into HTML string
-    const processedContent = await remark()
-        .use(html)
-        .process(matterResult.content)
-    const contentHtml = processedContent.toString()
+    // const processedContent = await remark()
+    //     .use(html)
+    //     .process(matterResult.content)
+    // const contentHtml = processedContent.toString()
 
     // Combine the data with the id
     return {
         id,
-        contentHtml,
+        // contentHtml,
+        content: matterResult.content,
         ...matterResult.data
     }
 }

--- a/lib/rehypePrism.js
+++ b/lib/rehypePrism.js
@@ -1,0 +1,90 @@
+var visit = require('unist-util-visit')
+var refractor = require('refractor/core')
+var jsx = require('refractor/lang/jsx')
+var java = require('refractor/lang/java')
+var c = require('refractor/lang/c')
+var cpp = require('refractor/lang/cpp')
+var ruby = require('refractor/lang/ruby')
+var python = require('refractor/lang/python')
+var css = require('refractor/lang/css')
+var cssExtras = require('refractor/lang/css-extras')
+var jsExtras = require('refractor/lang/js-extras')
+var sql = require('refractor/lang/sql')
+var typescript = require('refractor/lang/typescript')
+var tsx = require('refractor/lang/tsx')
+var markdown = require('refractor/lang/markdown')
+var json = require('refractor/lang/json')
+var bash = require('refractor/lang/bash')
+var docker = require('refractor/lang/docker')
+var makefile = require('refractor/lang/makefile')
+var latex = require('refractor/lang/latex')
+var graphql = require('refractor/lang/graphql')
+var git = require('refractor/lang/git')
+var go = require('refractor/lang/go')
+var vim = require('refractor/lang/vim')
+
+
+/* This plugin specifies how to highlight HTML syntax trees */
+module.exports = rehypePrism
+
+/* configure refractor for syntax highlighting */
+refractor.register(jsx)
+refractor.register(java)
+refractor.register(c)
+refractor.register(cpp)
+refractor.register(python)
+refractor.register(ruby)
+refractor.register(css)
+refractor.register(cssExtras)
+refractor.register(jsExtras)
+refractor.register(sql)
+refractor.register(typescript)
+refractor.register(tsx)
+refractor.register(markdown)
+refractor.register(json)
+refractor.register(bash)
+refractor.register(docker)
+refractor.register(makefile)
+refractor.register(latex)
+refractor.register(graphql)
+refractor.register(git)
+refractor.register(go)
+refractor.register(vim)
+
+
+refractor.alias({
+    javascript: ['js', 'javascript'],
+    cpp: ['cpp','c++'],
+    bash: ['bash', 'shell']
+})
+
+function rehypePrism(options) {
+    /* use options to specify if inline code blocks should be highlighted */
+    var inline = options && options.inline || false
+
+    return transformer
+
+    /* finds all <code/>, parse language, add className attribute, and syntax highlight */
+    function transformer(tree) {
+        visit(tree, visitor)
+    }
+
+    function visitor(node, index, parent) {
+        if ( node.tagName === 'code') {
+            let mdContent = node.children[0].value;
+
+            let lang = node.properties.className ? 
+                node.properties.className[0].slice(9).toLowerCase() : ''
+
+            if (lang) 
+                try {
+                    /* add className attribute */
+                    Object.assign(node, {
+                        children: refractor.highlight(mdContent, lang)
+                    })
+                } catch(err) {
+                    throw err;
+                }
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -341,6 +341,37 @@
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
       "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
     },
+    "@mapbox/hast-util-table-cell-style": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz",
+      "integrity": "sha512-QsEsh5YaDvHoMQ2YHdvZy2iDnU3GgKVBTcHf6cILyoWDZtPSdlG444pL/ioPYO/GpXSfODBb9sefEetfC4v9oA==",
+      "requires": {
+        "unist-util-visit": "^1.3.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+        },
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
+      }
+    },
     "@next/env": {
       "version": "10.0.5",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-10.0.5.tgz",
@@ -439,6 +470,14 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.14.0.tgz",
       "integrity": "sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw=="
+    },
+    "@types/hast": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
+      "integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
+      "requires": {
+        "@types/unist": "*"
+      }
     },
     "@types/json-schema": {
       "version": "7.0.6",
@@ -1300,6 +1339,17 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
+    "clipboard": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
+      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1749,6 +1799,12 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -2485,6 +2541,15 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -2585,18 +2650,29 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hast-to-hyperscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-9.0.1.tgz",
+      "integrity": "sha512-zQgLKqF+O2F72S1aa4y2ivxzSlko3MAvxkwG8ehGmNiqd98BIN3JM1rAJPmplEyLmGLO2QZYJtIneOSZ2YbJuA==",
+      "requires": {
+        "@types/unist": "^2.0.3",
+        "comma-separated-tokens": "^1.0.0",
+        "property-information": "^5.3.0",
+        "space-separated-tokens": "^1.0.0",
+        "style-to-object": "^0.3.0",
+        "unist-util-is": "^4.0.0",
+        "web-namespaces": "^1.0.0"
+      }
+    },
     "hast-util-is-element": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz",
       "integrity": "sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ=="
     },
-    "hast-util-sanitize": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-3.0.2.tgz",
-      "integrity": "sha512-+2I0x2ZCAyiZOO/sb4yNLFmdwPBnyJ4PBkVTUMKMqBwYNA+lXSgOmoRXlJFazoyid9QPogRRKgKhVEodv181sA==",
-      "requires": {
-        "xtend": "^4.0.0"
-      }
+    "hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="
     },
     "hast-util-to-html": {
       "version": "7.1.2",
@@ -2757,6 +2833,11 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "optional": true
+    },
+    "inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -3027,11 +3108,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
-    "longest-streak": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
-      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3119,19 +3195,6 @@
         "unist-util-generated": "^1.0.0",
         "unist-util-position": "^3.0.0",
         "unist-util-visit": "^2.0.0"
-      }
-    },
-    "mdast-util-to-markdown": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.2.tgz",
-      "integrity": "sha512-iRczns6WMvu0hUw02LXsPDJshBIwtUPbvHBWo19IQeU0YqmzlA8Pd30U8V7uiI0VPkxzS7A/NXBXH6u+HS87Zg==",
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "longest-streak": "^2.0.0",
-        "mdast-util-to-string": "^2.0.0",
-        "parse-entities": "^2.0.0",
-        "repeat-string": "^1.0.0",
-        "zwitch": "^1.0.0"
       }
     },
     "mdast-util-to-string": {
@@ -4095,6 +4158,14 @@
         }
       }
     },
+    "prismjs": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -4287,6 +4358,30 @@
         "picomatch": "^2.2.1"
       }
     },
+    "refractor": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.3.0.tgz",
+      "integrity": "sha512-c/jEhQjk1NDyTF3hMgtu8PigaqkWUv+c5+mBffZCTnjyrNSJkG+0eoTOJV/u0XCTuPfaFzJyj6MM4HnF0Wr27Q==",
+      "requires": {
+        "hastscript": "^6.0.0",
+        "parse-entities": "^2.0.0",
+        "prismjs": "~1.23.0"
+      },
+      "dependencies": {
+        "hastscript": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+          "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+          "requires": {
+            "@types/hast": "^2.0.0",
+            "comma-separated-tokens": "^1.0.0",
+            "hast-util-parse-selector": "^2.0.0",
+            "property-information": "^5.0.0",
+            "space-separated-tokens": "^1.0.0"
+          }
+        }
+      }
+    },
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -4306,24 +4401,21 @@
       "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
       "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q=="
     },
-    "remark": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
-      "integrity": "sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==",
+    "rehype-react": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-6.2.0.tgz",
+      "integrity": "sha512-XpR3p8ejdJ5CSEKqAfASIrkD+KaHLy0JOqXu9zM32tvkr1cUeM7AeidF6Q8eQ/wtMvcJb+h/L4QRwg1eFwBggQ==",
       "requires": {
-        "remark-parse": "^9.0.0",
-        "remark-stringify": "^9.0.0",
-        "unified": "^9.1.0"
+        "@mapbox/hast-util-table-cell-style": "^0.1.3",
+        "hast-to-hyperscript": "^9.0.0"
       }
     },
-    "remark-html": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-13.0.1.tgz",
-      "integrity": "sha512-K5KQCXWVz+harnyC+UVM/J9eJWCgjYRqFeZoZf2NgP0iFbuuw/RgMZv3MA34b/OEpGnstl3oiOUtZzD3tJ+CBw==",
+    "rehype-stringify": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-8.0.0.tgz",
+      "integrity": "sha512-VkIs18G0pj2xklyllrPSvdShAV36Ff3yE5PUO9u36f6+2qJFnn22Z5gKwBOwgXviux4UC7K+/j13AnZfPICi/g==",
       "requires": {
-        "hast-util-sanitize": "^3.0.0",
-        "hast-util-to-html": "^7.0.0",
-        "mdast-util-to-hast": "^10.0.0"
+        "hast-util-to-html": "^7.1.1"
       }
     },
     "remark-parse": {
@@ -4334,12 +4426,12 @@
         "mdast-util-from-markdown": "^0.8.0"
       }
     },
-    "remark-stringify": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
-      "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
+    "remark-rehype": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-8.0.0.tgz",
+      "integrity": "sha512-gVvOH02TMFqXOWoL6iXU7NXMsDJguNkNuMrzfkQeA4V6WCyHQnOKptn+IQBVVPuIH2sMJBwo8hlrmtn1MLTh9w==",
       "requires": {
-        "mdast-util-to-markdown": "^0.6.0"
+        "mdast-util-to-hast": "^10.0.0"
       }
     },
     "remove-trailing-separator": {
@@ -4550,6 +4642,12 @@
           }
         }
       }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "optional": true
     },
     "semver": {
       "version": "7.3.4",
@@ -5047,6 +5145,14 @@
         "schema-utils": "^2.6.6"
       }
     },
+    "style-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+      "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+      "requires": {
+        "inline-style-parser": "0.1.1"
+      }
+    },
     "styled-components": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.2.1.tgz",
@@ -5337,6 +5443,12 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "optional": true
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -5909,6 +6021,11 @@
         }
       }
     },
+    "web-namespaces": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
+      "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -6051,11 +6168,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-    },
-    "zwitch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
-      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,14 @@
     "next": "^10.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "remark": "^13.0.0",
-    "remark-html": "^13.0.1",
-    "styled-components": "^5.2.1"
+    "refractor": "^3.3.0",
+    "rehype-react": "^6.2.0",
+    "rehype-stringify": "^8.0.0",
+    "remark-parse": "^9.0.0",
+    "remark-rehype": "^8.0.0",
+    "styled-components": "^5.2.1",
+    "unified": "^9.2.0",
+    "unist-util-visit": "^2.0.3"
   },
   "devDependencies": {
     "babel-plugin-styled-components": "^1.8.0"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,5 @@
 import '../styles/global.css'
+import '../styles/prism.css'
 
 export default function App({ Component, pageProps }) {
     return <Component {...pageProps} />

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -3,6 +3,12 @@ import Head from 'next/head'
 import Layout from '../../components/layout'
 import { getAllPostIds, getPostData } from '../../lib/posts'
 import Date from '../../components/date'
+import unified from 'unified'
+import markdown from 'remark-parse'
+import { Code, Pre } from '../../components/code_block'
+import remark2rehype from 'remark-rehype'
+import rehypePrism from '../../lib/rehypePrism'
+import rehype2react from 'rehype-react'
 
 export async function getStaticPaths() {
     const paths = getAllPostIds();
@@ -32,7 +38,21 @@ export default function Post({ postData }) {
                 <div className={utilStyles.lightText}>
                     <Date dateString={postData.date} />
                 </div>
-                <div dangerouslySetInnerHTML={{ __html: postData.contentHtml }} />
+                {/* <div dangerouslySetInnerHTML={{ __html: postData.contentHtml }} /> */}
+                {
+                    unified()
+                        .use(markdown)
+                        .use(remark2rehype)
+                        .use(rehypePrism)
+                        .use(rehype2react, {
+                            createElement: React.createElement,
+                            components: {
+                                pre: Pre,
+                                code: Code
+                            }
+                        })
+                        .processSync(postData.content).result
+                }
             </article>
         </Layout>
     )

--- a/styles/prism.css
+++ b/styles/prism.css
@@ -1,0 +1,143 @@
+/* PrismJS 1.23.0
+https://prismjs.com/download.html#themes=prism&languages=markup+css+clike+javascript+bash+c+cpp+css-extras+docker+git+go+graphql+java+js-extras+json+latex+makefile+markdown+python+jsx+tsx+ruby+sql+typescript+vim */
+/**
+ * prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+	color: black;
+	background: none;
+	text-shadow: 0 1px white;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+	text-shadow: none;
+	background: #b3d4fc;
+}
+
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
+	text-shadow: none;
+	background: #b3d4fc;
+}
+
+@media print {
+	code[class*="language-"],
+	pre[class*="language-"] {
+		text-shadow: none;
+	}
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #f5f2f0;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+	padding: .1em;
+	border-radius: .3em;
+	white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: slategray;
+}
+
+.token.punctuation {
+	color: #999;
+}
+
+.token.namespace {
+	opacity: .7;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+	color: #905;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+	color: #690;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+	color: #9a6e3a;
+	/* This background color was intended by the author of this theme. */
+	/* background: hsla(0, 0%, 100%, .5); */
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+	color: #07a;
+}
+
+.token.function,
+.token.class-name {
+	color: #DD4A68;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+	color: #e90;
+}
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}
+


### PR DESCRIPTION
resolves #4 

## Summary of your work
- add syntax highlighting support for the following languages:
    jsx, java, c, cpp, ruby, python, css, cssExtras, jsExtras, sql, typescript, tsx, markdown, json, bash, docker, makefile, latex, graphql, git, go, vim
- wrote a plugin **rehypePrism** to modify the hast to add syntax highlighting for `<code/>` elements

Each post page is generated from a **markdown** file using the following procedure:
1. content of the markdown file is read, passed to the `Post` page as a prop
2. `remark-parse` transforms the string into an unist AST 
3. `remark-rehype` transforms the AST of markdown into an AST of HTML in hast format
4. `rehypePrism` modifies the AST to add syntax highlighting for `<code/>` blocks
5. `rehype-react` compiles the AST to React elements which are in turn rendered by React

## Result of your work
![image](https://user-images.githubusercontent.com/25857014/105185317-5627a880-5b6b-11eb-807f-e0b13fca3be4.png)

